### PR TITLE
Adds posts and comments resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+/.vscode
+/wiki

--- a/API/app.js
+++ b/API/app.js
@@ -42,6 +42,9 @@ app.use('/channel', channelController);
 const userController = require('./controllers/userController');
 app.use('/users', userController);
 
+const postController = require('./controllers/postController');
+app.use('/posts', postController);
+
 // Start the server on port 3000
 // This will have to be updated once we push to production to use the port
 // of whatever we're hosted on

--- a/API/app.js
+++ b/API/app.js
@@ -37,7 +37,7 @@ const exampleController = require('./controllers/exampleController');
 app.use('/examples', exampleController);
 
 const channelController = require('./controllers/channelController');
-app.use('/channel', channelController);
+app.use('/channels', channelController);
 
 const userController = require('./controllers/userController');
 app.use('/users', userController);

--- a/API/config/options.js
+++ b/API/config/options.js
@@ -1,0 +1,4 @@
+module.exports = {
+  postCharacterLimit: 1000,
+  commentCharacterLimit: 500
+}

--- a/API/controllers/channelController.js
+++ b/API/controllers/channelController.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 
 require('../models/Channels');
 const Channel = mongoose.model('Channel');
+const { verifyToken } = require('../helpers/authorization');
+const { classifyError } = require('../helpers/formatters');
 
 /**
  * Methods:
@@ -19,19 +21,13 @@ const Channel = mongoose.model('Channel');
 /**
  * Create a new channel
  */
-router.post('/', (req, res) => {
+router.post('/', verifyToken, (req, res) => {
   Channel.create(req.body).then(channel => {
-    res.json(200, channel);
+    res.json(channel);
   })
   .catch(err => {
-    if (typeof err === 'object') {
-      // Actual runtime error
-      res.json(500, err.message);
-    }
-    else {
-      // Purposefully did not complete action, returned message
-      res.json(403, err);
-    }
+    var clf = classifyError(err);
+    res.status(clf.status).json(clf.message);
   });
 });
 
@@ -40,67 +36,62 @@ router.post('/', (req, res) => {
  */
 router.get('/:id', (req, res) => {
   Channel.get(req.params.id).then(channel => {
-    res.json(200, channel);
+    res.json(channel);
   })
   .catch(err => {
-    if (typeof err === 'object') {
-      res.json(500, err.message);
-    }
-    else {
-      res.json(403, err);
-    }
+    var clf = classifyError(err);
+    res.status(clf.status).json(clf.message);
   });
 });
+
+/**
+ * Get all channels
+ */
+router.get('/', (req, res) => {
+  Channel.getAll().then(channels => {
+    res.json(channels);
+  })
+  .catch(err => {
+    res.status(500).json(err.message);
+  });
+})
 
 /**
  * Get posts from a specific channel
  */
 router.get('/:id/posts', (req, res) => {
   Channel.getPosts(req.params.id).then(posts => {
-    res.json(200, posts);
+    res.json(posts);
   })
   .catch(err => {
-    if (typeof err === 'object') {
-      res.json(500, err.message);
-    }
-    else {
-      res.json(403, err);
-    }
+    var clf = classifyError(err);
+    res.status(clf.status).json(clf.message);
   });
 });
 
 /**
  * Update a channel
  */
-router.put('/:id', (req, res) => {
-  const id = req.params.id;
-  Channel.updateChannel(id, req.body).then(() => {
-    res.redirect(`/channel/${id}`);
+router.put('/:id', verifyToken, (req, res) => {
+  Channel.updtedChannel(req.params.id, req.body).then(channel => {
+    res.json(channel);
   })
   .catch(err => {
-    if (typeof err === 'object') {
-      res.json(500, err.message);
-    }
-    else {
-      res.json(403, err);
-    }
+    var clf = classifyError(err);
+    res.status(clf.status).json(clf.message);
   });
 });
 
 /**
  * Delete a channel
  */
-router.delete('/:id', (req, res) => {
+router.delete('/:id', verifyToken, (req, res) => {
   Channel.delete(req.params.id).then(msg => {
-    res.json(200, msg);
+    res.json(msg);
   })
   .catch(err => {
-    if (typeof err === 'object') {
-      res.json(500, err.message);
-    }
-    else {
-      res.json(403, err);
-    }
+    var clf = classifyError(err);
+    res.status(clf.status).json(clf.message);
   });
 });
 

--- a/API/controllers/channelController.js
+++ b/API/controllers/channelController.js
@@ -54,7 +54,6 @@ router.get('/:id', (req, res) => {
 
 /**
  * Get posts from a specific channel
- * TODO: Finish once we build out Posts model
  */
 router.get('/:id/posts', (req, res) => {
   Channel.getPosts(req.params.id).then(posts => {

--- a/API/controllers/channelController.js
+++ b/API/controllers/channelController.js
@@ -26,8 +26,8 @@ router.post('/', verifyToken, (req, res) => {
     res.json(channel);
   })
   .catch(err => {
-    var clf = classifyError(err);
-    res.status(clf.status).json(clf.message);
+    var errRes = classifyError(err);
+    res.status(errRes.status).json(errRes.message);
   });
 });
 
@@ -39,8 +39,8 @@ router.get('/:id', (req, res) => {
     res.json(channel);
   })
   .catch(err => {
-    var clf = classifyError(err);
-    res.status(clf.status).json(clf.message);
+    var errRes = classifyError(err);
+    res.status(errRes.status).json(errRes.message);
   });
 });
 
@@ -64,8 +64,8 @@ router.get('/:id/posts', (req, res) => {
     res.json(posts);
   })
   .catch(err => {
-    var clf = classifyError(err);
-    res.status(clf.status).json(clf.message);
+    var errRes = classifyError(err);
+    res.status(errRes.status).json(errRes.message);
   });
 });
 
@@ -77,8 +77,8 @@ router.put('/:id', verifyToken, (req, res) => {
     res.json(channel);
   })
   .catch(err => {
-    var clf = classifyError(err);
-    res.status(clf.status).json(clf.message);
+    var errRes = classifyError(err);
+    res.status(errRes.status).json(errRes.message);
   });
 });
 
@@ -90,8 +90,8 @@ router.delete('/:id', verifyToken, (req, res) => {
     res.json(msg);
   })
   .catch(err => {
-    var clf = classifyError(err);
-    res.status(clf.status).json(clf.message);
+    var errRes = classifyError(err);
+    res.status(errRes.status).json(errRes.message);
   });
 });
 

--- a/API/controllers/postController.js
+++ b/API/controllers/postController.js
@@ -1,0 +1,118 @@
+const express = require('express');
+const router = express.Router();
+const mongoose = require('mongoose');
+const _ = require('lodash');
+
+require('../models/Posts');
+const Post = mongoose.model('Post');
+
+/**
+ * Methods:
+ *  post(/) => Creates new post
+ *  get(/:id) => Gets post by id
+ *  put(/:id) => Updates post with given id
+ *  delete(/:id) => Deletes post with given id
+ *  get(/:id/comments) => Gets all comments for post
+ *  post(/:id) => Adds a new comment to the post
+ */
+
+/**
+ * Create new post
+ */
+router.post('/', (req, res) => {
+  Post.create(req.body).then(post => {
+    res.json(200, post);
+  })
+  .catch(err => {
+    if (typeof err === 'object') {
+      res.json(500, err.message);
+    } else {
+      res.json(403, err);
+    }
+  })
+})
+
+/**
+ * Get post by id
+ */
+router.get('/:id', (req, res) => {
+  Post.get(req.params.id).then(post => {
+    res.json(200, post);
+  })
+  .catch(err => {
+    if (typeof err === 'object') {
+      res.json(500, err.msg);
+    } else {
+      res.json(403, err);
+    }
+  });
+});
+
+/**
+ * Update a post
+ */
+router.put('/:id', (req, res) => {
+  const id = req.params.id;
+  Post.updatePost(id, req.body).then(() => {
+    res.redirect(`/posts/${id}`);
+  })
+  .catch(err => {
+    if (typeof err === 'object') {
+      res.json(500, err.message);
+    } else {
+      res.json(403, err);
+    }
+  });
+});
+
+/**
+ * Delete a post
+ */
+router.delete('/:id', (req, res) => {
+  Post.delete(req.params.id).then((msg) => {
+    res.json(200, msg);
+  })
+  .catch(err => {
+    if (typeof err === 'object') {
+      res.json(500, err.message);
+    } else {
+      res.json(403, err);
+    }
+  });
+});
+
+/**
+ * Get all comments associated with the post
+ */
+router.get('/:id/comments', (req, res) => {
+  Post.getComments(req.params.id).then(comments => {
+    res.json(200, comments);
+  })
+  .catch(err => {
+    if (typeof err === 'object') {
+      res.json(500, err.message);
+    }
+    else {
+      res.json(403, err);
+    }
+  });
+});
+
+/**
+ * Add a new comment to the post
+ */
+router.post('/:id', (req, res) => {
+  Post.addComment(req.params.id, req.body).then(comment => {
+    res.json(200, comment);
+  })
+  .catch(err => {
+    if (typeof err === 'object') {
+      res.json(500, err.message);
+    }
+    else {
+      res.json(403, err);
+    }
+  });
+});
+
+module.exports = router;

--- a/API/helpers/formatters.js
+++ b/API/helpers/formatters.js
@@ -1,0 +1,38 @@
+const express = require('express');
+
+const config = require('../config/options');
+
+/**
+ * Dispatch errors in an appropriate format corresponding to their type.
+ * If error is an object, it is an internal server error (ie something broke).
+ * If it is a string, it is a rejection message raised due to an invalid operation
+ * according to our business logic, for example attempting to create an existing channel.
+ */
+exports.classifyError = (err) => {
+  if (typeof err === 'object') {
+    return ({ status: 500, message: err.message });
+  } else if (typeof err === 'string') {
+    return ({ status: 403, message: err });
+  } else {
+    raise (new Error(`Invalid error type supplied to errors.classifyError: ${err}`));
+  }
+}
+
+/**
+ * Ensure tags stored in database are an array of lower-case strings
+ * @param {iterable} tagsObj
+ * @return {array}
+ */
+exports.formatTags = (tags) => {
+  var formattedTags = [];
+  if (typeof tags === 'object') {
+    tags.forEach((tag) => {
+      formattedTags.push(tag.toLowerCase());
+    });
+  } else if (typeof tags === 'string') {
+    formattedTags.push(tags.toLowerCase());
+  } else if (typeof tags === 'number') {
+    formattedTags.push(`${tags}`);
+  } else return null;
+  return formattedTags;
+}

--- a/API/models/Channels.js
+++ b/API/models/Channels.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
-const _ = require('lodash');
+const ObjectId = mongoose.Types.ObjectId;
 const Schema = mongoose.Schema;
+const _ = require('lodash');
 
 require('./Posts');
 const Post = mongoose.model('Post');
@@ -44,7 +45,7 @@ ChannelSchema.statics.create = function(channel) {
 }
 
 ChannelSchema.statics.get = function(id) {
-  if (typeof id === 'string') id = mongoose.Types.ObjectId(id);
+  id = ObjectId(id);
 
 	return new Promise((resolve, reject) => {
 		this.findById(id).then(channel => {
@@ -90,11 +91,9 @@ ChannelSchema.statics.getPosts = function(id) {
 }
 
 ChannelSchema.statics.updateChannel = function(id, updatedChannelObj) {
-  if (typeof id === 'string') id = mongoose.Types.ObjectId(id);
+	id = ObjectId(id);
 
-	var name;
-	if (updatedChannelObj.name) name = updatedChannelObj.name.toLowerCase();
-
+	var name = updatedChannelObj.name.toLowerCase();
 	var formattedTags = formatTags(updatedChannelObj.tags);
 
 	return new Promise((resolve, reject) => {
@@ -119,8 +118,8 @@ ChannelSchema.statics.updateChannel = function(id, updatedChannelObj) {
 }
 
 ChannelSchema.statics.delete = function(id) {
-  if (typeof id === 'string') id = mongoose.Types.ObjectId(id);
-
+	id = ObjectId(id);
+	
 	return new Promise((resolve, reject) => {
 		this.deleteOne({ _id: id }).then(() => {
 			resolve('Successfully deleted channel');

--- a/API/models/Posts.js
+++ b/API/models/Posts.js
@@ -1,0 +1,177 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+// TODO: implement comments model
+// require('./Comments');
+// const Comment = mongoose.model('Comment');
+
+const PostSchema = new Schema({
+	author: {
+    //type: Schema.Types.ObjectId,
+    type: String,
+    required: true,
+    ref: 'User'
+  },
+  subscribedUsers: {
+    type: Array,
+    default: [],
+    ref: 'User'
+  },
+	content: {
+		type: String,
+		required: true,
+  },
+  image: {
+    type: Buffer,
+  },
+	tags: {
+		type: Array,
+		required: true,
+  },
+  comments: {
+    type: Array,
+    ref: 'Comment'
+  },
+  createdAt: {
+    type: Object,
+  },
+  updatedAt: {
+    type: Object,
+  }
+});
+
+PostSchema.statics.create = function(post) {
+  // Implement a character limit client-side
+  if (!post.createdAt) {
+    post.createdAt = new Date();
+  }
+	var formattedTags = [];
+	post.tags.forEach((tag) => {
+    formattedTags.push(tag.toLowerCase());
+  });
+  var post = {
+    ...post,
+    subscribedUsers: post.author,
+    tags: formattedTags,
+  }
+	return new Promise((resolve, reject) => {
+    this.find({ content: post.content }).then(existingPost => {
+      if (existingPost && existingPost.length) {
+        reject(`Hmm, it looks like a post with the exact same content already exists. Try something new!`);
+      } else {
+        const newPost = new this(post);
+        newPost.save().then(post => {
+          resolve(post);
+        })
+        .catch(err => {
+          reject(err);
+        });
+      }
+    })
+    .catch(err => {
+      reject(err);
+    });
+  });
+}
+
+PostSchema.statics.get = function(id) {
+  if (typeof id === 'string') id = mongoose.Types.ObjectId(id);
+
+  return new Promise((resolve, reject) => {
+    this.findById(id).then(post => {
+      if (post) {
+        resolve(post);
+      }
+      else {
+        reject(`Couldn't find a post with that ID`);
+      }
+    })
+    .catch(err => {
+      reject(err);
+    });
+  })
+}
+
+PostSchema.statics.updatePost = function(id, postObj) {
+  if (typeof id === 'string') id = mongoose.Types.ObjectId(id);
+
+  postObj = {
+    ...postObj,
+    updatedAt: new Date()
+  }
+
+  return new Promise((resolve, reject) => {
+    this.update({ _id: id }, postObj).then(post => {
+      resolve();
+    })
+    .catch(err => {
+      reject(err);
+    })
+  });
+}
+
+PostSchema.statics.delete = function(id) {
+  if (typeof id === 'string') id = mongoose.Types.ObjectId(id);
+
+  return new Promise((resolve, reject) => {
+    this.deleteOne({ _id: id }).then(() => {
+      resolve(`Successfully deleted post`);
+    })
+    .catch(err => {
+      reject(err);
+    });
+  });
+}
+
+PostSchema.statics.findByTags = function(tags) {
+  return new Promise((resolve, reject) => {
+    // format tags into array
+    var tagArray = [];
+    if (typeof tags === 'object') {
+      // likely in format of database query return
+      tags.forEach((tag) => {
+        tagArray.push(tag);
+      });
+    } else if (typeof tags === 'string') {
+      // assume only one tag passed in as string
+      tagArray.push(tags);
+    } else tagArray = tags; // assume already an array
+
+    this.find({ tags: {$in: tags} }).then(posts => {
+      resolve(posts);
+    })
+    .catch(err => {
+      reject(err);
+    });
+  });
+}
+
+PostSchema.statics.getComments = function(id) {
+  if (typeof id === 'string') id = mongoose.Types.ObjectId(id);
+
+  return new Promise((resolve, reject) => {
+    this.get(id).then(post => {
+      if (post.comments) {
+        resolve(post.comments);
+      } else {
+        reject(`No comments found for this post`);
+      }
+    })
+    .catch(err => {
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Add a comment to a post instance.
+ * This should call the Comment create method, then add
+ * that comment to its own document.
+ */
+PostSchema.statics.addComment = function(id, commentObj){
+/**
+ * TODO: implement.
+ */
+}
+
+mongoose.model('Post', PostSchema);


### PR DESCRIPTION
Adds basic routes for posts, but still missing integration with comments (get all comments for a post and add new comment). Has been integrated with the `channnel/:id/posts` route, which returns all posts with the same tags as the specified channel! Neat-O. Need to update once User model is in to reference the userID of the poster.

----UPDATE----
Comments added as subdocument to Post Schema, comment routes are defined in PostController but exposed as separate endpoints.